### PR TITLE
Restart synapse on re-installation

### DIFF
--- a/tasks/deployment.yml
+++ b/tasks/deployment.yml
@@ -74,4 +74,6 @@
   tags:
     - skip_ansible_lint # skip when clause
     - pre_install
+  notify:
+    - "restart matrix-synapse"
 


### PR DESCRIPTION
If we re-install synapse because the git checkout has changed, restart it after installing.