### PR TITLE
update synapse default version to master

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,5 +17,5 @@ matrix_synapse_turn_uri: "{{ matrix_turn_uri }}"
 matrix_synapse_registration_secret: "{{ matrix_registration_secret }}"
 matrix_synapse_macaroon_secret_key: "{{ matrix_macaroon_key }}"
 matrix_synapse_signing_key_path: "/opt/synapse/ssl/{{ matrix_synapse_domain }}.signing.key"
-matrix_synapse_version: "v0.33.4"
+matrix_synapse_version: "master"
 matrix_synapse_log_days_keep: 30

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,5 +17,5 @@ matrix_synapse_turn_uri: "{{ matrix_turn_uri }}"
 matrix_synapse_registration_secret: "{{ matrix_registration_secret }}"
 matrix_synapse_macaroon_secret_key: "{{ matrix_macaroon_key }}"
 matrix_synapse_signing_key_path: "/opt/synapse/ssl/{{ matrix_synapse_domain }}.signing.key"
-matrix_synapse_version: "v0.28.1"
+matrix_synapse_version: "v0.33.4"
 matrix_synapse_log_days_keep: 30


### PR DESCRIPTION
Can we maybe just have the task take master if we don't explicitly specify a version? 